### PR TITLE
Updated EntityFrameworkCore packages to use net10 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 Version `1.0.31`
 
-- Upgraded `EntityFrameworkCore` packages in `Paradigm.Enterprise.Data` projects.
+ - Upgraded EF Core and related data-access packages to `10.x` (including `Microsoft.EntityFrameworkCore*`, `EntityFrameworkCore.Exceptions.SqlServer`, and `Npgsql.EntityFrameworkCore.PostgreSQL`).
+ - Upgraded additional dependencies (e.g., `Azure.Identity`, `Azure.Storage.Blobs`, `Microsoft.Data.SqlClient`, and Redis packages).
+ - Updated some projects that previously multi-targeted `net9.0;net10.0` to target `net10.0` only.
 
 Version `1.0.30`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+Version `1.0.31`
+
+- Upgraded `EntityFrameworkCore` packages in `Paradigm.Enterprise.Data` projects.
+
 Version `1.0.30`
 
 - Added support for managed identity to `Services.Cache` and `Services.Email` packages.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="ExcelDataReader" Version="3.8.0" />
     <PackageVersion Include="Mapster" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="1.0.0" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,32 +5,32 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Communication.Email" Version="1.1.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
-    <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="8.1.3" />
+    <PackageVersion Include="EntityFrameworkCore.Exceptions.SqlServer" Version="10.0.1" />
     <PackageVersion Include="ExcelDataReader" Version="3.8.0" />
     <PackageVersion Include="Mapster" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.2.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.12" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.12" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.12" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.12" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.12" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.12" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.12" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.12" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.12" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="MSTest" Version="4.2.2" />
+    <PackageVersion Include="MSTest" Version="4.2.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="NSwag.CodeGeneration.TypeScript" Version="14.7.1" />
   </ItemGroup>
 </Project>

--- a/src/Paradigm.Enterprise.CodeGenerator/Paradigm.Enterprise.CodeGenerator.csproj
+++ b/src/Paradigm.Enterprise.CodeGenerator/Paradigm.Enterprise.CodeGenerator.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Data.PostgreSql/Paradigm.Enterprise.Data.PostgreSql.csproj
+++ b/src/Paradigm.Enterprise.Data.PostgreSql/Paradigm.Enterprise.Data.PostgreSql.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Data.SqlServer/Paradigm.Enterprise.Data.SqlServer.csproj
+++ b/src/Paradigm.Enterprise.Data.SqlServer/Paradigm.Enterprise.Data.SqlServer.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Data.SqlServer/Paradigm.Enterprise.Data.SqlServer.csproj
+++ b/src/Paradigm.Enterprise.Data.SqlServer/Paradigm.Enterprise.Data.SqlServer.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="EntityFrameworkCore.Exceptions.SqlServer" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
   </ItemGroup>
 

--- a/src/Paradigm.Enterprise.Data/Paradigm.Enterprise.Data.csproj
+++ b/src/Paradigm.Enterprise.Data/Paradigm.Enterprise.Data.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Domain/Paradigm.Enterprise.Domain.csproj
+++ b/src/Paradigm.Enterprise.Domain/Paradigm.Enterprise.Domain.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Interfaces/Paradigm.Enterprise.Interfaces.csproj
+++ b/src/Paradigm.Enterprise.Interfaces/Paradigm.Enterprise.Interfaces.csproj
@@ -8,7 +8,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Providers/Paradigm.Enterprise.Providers.csproj
+++ b/src/Paradigm.Enterprise.Providers/Paradigm.Enterprise.Providers.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Services.BlobStorage/AzureBlobStorage/AzureBlobStorageContainer.cs
+++ b/src/Paradigm.Enterprise.Services.BlobStorage/AzureBlobStorage/AzureBlobStorageContainer.cs
@@ -97,7 +97,7 @@ namespace Paradigm.Enterprise.Services.BlobStorage.AzureBlobStorage
             try
             {
                 // Call the listing operation and return pages of the specified size.
-                var resultSegment = _containerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, blobName).AsPages(default, 5000);
+                var resultSegment = _containerClient.GetBlobsAsync(BlobTraits.None, BlobStates.None, blobName, cancellationToken).AsPages(default, 5000);
 
                 // Enumerate the blobs returned for each page.
                 await foreach (var blobPage in resultSegment)
@@ -321,7 +321,12 @@ namespace Paradigm.Enterprise.Services.BlobStorage.AzureBlobStorage
         /// <returns></returns>
         private async Task<List<BlobClient>> GetBlobClientsAsync(string from)
         {
-            var blobPages = _containerClient.GetBlobsByHierarchyAsync(delimiter: "/", prefix: from).AsPages(pageSizeHint: 5000);
+            var blobPages = _containerClient.GetBlobsByHierarchyAsync(
+                traits: BlobTraits.None,
+                states: BlobStates.None,
+                delimiter: "/",
+                prefix: from,
+                cancellationToken: CancellationToken.None).AsPages(pageSizeHint: 5000);
             var blobs = new List<BlobClient>();
 
             await foreach (var blobPage in blobPages)
@@ -350,7 +355,6 @@ namespace Paradigm.Enterprise.Services.BlobStorage.AzureBlobStorage
                 { nameof(properties.ContentHash), properties.ContentHash },
                 { nameof(properties.ContentLength), properties.ContentLength },
                 { nameof(properties.ETag), properties.ETag },
-                //{ nameof(properties.ContentMD5), properties.ContentMD5 }, TODO
                 { nameof(properties.LastModified), properties.LastModified }
             };
         }

--- a/src/Paradigm.Enterprise.Services.BlobStorage/AzureBlobStorage/AzureBlobStorageContainer.cs
+++ b/src/Paradigm.Enterprise.Services.BlobStorage/AzureBlobStorage/AzureBlobStorageContainer.cs
@@ -126,7 +126,7 @@ namespace Paradigm.Enterprise.Services.BlobStorage.AzureBlobStorage
         /// <param name="cancellationToken">The cancellation token.</param>
         public async Task CopyFolderAsync(string from, string to, CancellationToken cancellationToken)
         {
-            var blobClients = await GetBlobClientsAsync(from);
+            var blobClients = await GetBlobClientsAsync(from, cancellationToken);
 
             foreach (var blobClient in blobClients)
             {
@@ -222,7 +222,7 @@ namespace Paradigm.Enterprise.Services.BlobStorage.AzureBlobStorage
             if (destinationContainer is not AzureBlobStorageContainer container)
                 throw new Exception("Wrong container type.");
 
-            var blobClients = await GetBlobClientsAsync(string.Empty);
+            var blobClients = await GetBlobClientsAsync(string.Empty, cancellationToken);
 
             foreach (var blobClient in blobClients)
             {
@@ -267,7 +267,7 @@ namespace Paradigm.Enterprise.Services.BlobStorage.AzureBlobStorage
             if (destinationContainer is not AzureBlobStorageContainer container)
                 throw new Exception("Wrong container type.");
 
-            var blobClients = await GetBlobClientsAsync(from);
+            var blobClients = await GetBlobClientsAsync(from, cancellationToken);
 
             foreach (var blobClient in blobClients)
             {
@@ -319,14 +319,14 @@ namespace Paradigm.Enterprise.Services.BlobStorage.AzureBlobStorage
         /// </summary>
         /// <param name="from">From.</param>
         /// <returns></returns>
-        private async Task<List<BlobClient>> GetBlobClientsAsync(string from)
+        private async Task<List<BlobClient>> GetBlobClientsAsync(string from, CancellationToken cancellationToken)
         {
             var blobPages = _containerClient.GetBlobsByHierarchyAsync(
                 traits: BlobTraits.None,
                 states: BlobStates.None,
                 delimiter: "/",
                 prefix: from,
-                cancellationToken: CancellationToken.None).AsPages(pageSizeHint: 5000);
+                cancellationToken: cancellationToken).AsPages(pageSizeHint: 5000);
             var blobs = new List<BlobClient>();
 
             await foreach (var blobPage in blobPages)
@@ -334,7 +334,7 @@ namespace Paradigm.Enterprise.Services.BlobStorage.AzureBlobStorage
                     if (blobItem.IsBlob)
                         blobs.Add(GetBlobClient(blobItem.Blob.Name));
                     else
-                        blobs.AddRange(await GetBlobClientsAsync(blobItem.Prefix));
+                        blobs.AddRange(await GetBlobClientsAsync(blobItem.Prefix, cancellationToken));
 
             return blobs;
         }

--- a/src/Paradigm.Enterprise.Services.BlobStorage/Paradigm.Enterprise.Services.BlobStorage.csproj
+++ b/src/Paradigm.Enterprise.Services.BlobStorage/Paradigm.Enterprise.Services.BlobStorage.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Services.Cache/Paradigm.Enterprise.Services.Cache.csproj
+++ b/src/Paradigm.Enterprise.Services.Cache/Paradigm.Enterprise.Services.Cache.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Services.Core/Paradigm.Enterprise.Services.Core.csproj
+++ b/src/Paradigm.Enterprise.Services.Core/Paradigm.Enterprise.Services.Core.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Services.Email/Paradigm.Enterprise.Services.Email.csproj
+++ b/src/Paradigm.Enterprise.Services.Email/Paradigm.Enterprise.Services.Email.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.Services.TableReader/Paradigm.Enterprise.Services.TableReader.csproj
+++ b/src/Paradigm.Enterprise.Services.TableReader/Paradigm.Enterprise.Services.TableReader.csproj
@@ -7,7 +7,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>

--- a/src/Paradigm.Enterprise.WebApi/Paradigm.Enterprise.WebApi.csproj
+++ b/src/Paradigm.Enterprise.WebApi/Paradigm.Enterprise.WebApi.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <Version>1.0.30</Version>
+    <Version>1.0.31</Version>
     <Authors>Miracle Devs</Authors>
     <Company>Miracle Devs</Company>
     <Product>Paradigm Enterprise</Product>


### PR DESCRIPTION
### What does this PR fix/introduce?

Updated Microsoft dependencies that were still using net9